### PR TITLE
generate bcrypt hashes using the '2a' mcf scheme identifier by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Use it in your project by adding the following to your project *pom.xml*:
 
 # Local fork notes:
 
+square-2:
+Introduce a gensalt() method that takes the schema id as a parameter and replace
+the method with the original signature to use a default of '2a'. This change should
+preserve compatibility with other bcrypt libraries that are not yet updated to
+handle the '2b' schema.
+
 square-1: 
 Supports $2b$ prefix for modular crypt formatted hashes on verification, and writes
 using the same updated prefix. See http://www.openwall.com/lists/oss-security/2012/01/02/4

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.svenkubiak</groupId>
 	<artifactId>jBCrypt</artifactId>
-	<version>0.4.1-51d5f7f-square-1</version>
+	<version>0.4.1-51d5f7f-square-2</version>
 	<packaging>bundle</packaging>
 	<name>jBCrypt</name>
 	<url>http://www.mindrot.org/projects/jBCrypt</url>
@@ -28,7 +28,7 @@
 		<connection>scm:git:git@github.com:davidmarkcarlson/jBCrypt.git</connection>
 		<developerConnection>scm:git:git@github.com:davidmarkcarlson/jBCrypt.git</developerConnection>
 		<url>git@github.com:davidmarkcarlson/jBCrypt.git</url>
-		<tag>0.4.1-51d5f7f-square-1</tag>
+		<tag>0.4.1-51d5f7f-square-2</tag>
 	</scm>
 	<description>A Java implementation of OpenBSD's Blowfish password hashing code http://www.mindrot.org/projects/jBCrypt</description>
 	<build>

--- a/src/main/java/org/mindrot/jbcrypt/BCrypt.java
+++ b/src/main/java/org/mindrot/jbcrypt/BCrypt.java
@@ -703,7 +703,9 @@ public class BCrypt {
 	}
 
 	/**
-	 * Generate a salt for use with the BCrypt.hashpw() method
+	 * Generate a salt for use with the BCrypt.hashpw() method. Use
+	 * '2a' as the MCF scheme id.
+	 *
 	 * @param log_rounds	the log2 of the number of rounds of
 	 * hashing to apply - the work factor therefore increases as
 	 * 2**log_rounds.
@@ -711,12 +713,27 @@ public class BCrypt {
 	 * @return	an encoded salt value
 	 */
 	public static String gensalt(int log_rounds, SecureRandom random) {
+		return gensalt("2a", log_rounds, random);
+	}
+
+	/**
+	 * Generate a salt for use with the BCrypt.hashpw() method
+	 * @param schemeId  an schema identifier in the modular crypt format encoding.
+	 * @param log_rounds  the log2 of the number of rounds of
+	 * hashing to apply - the work factor therefore increases as
+	 * 2**log_rounds.
+	 * @param random    an instance of SecureRandom to use
+	 * @return	an encoded salt value
+	 */
+	public static String gensalt(String schemeId, int log_rounds, SecureRandom random) {
 		StringBuffer rs = new StringBuffer();
 		byte rnd[] = new byte[BCRYPT_SALT_LEN];
 
 		random.nextBytes(rnd);
 
-		rs.append("$2b$");
+		rs.append("$");
+		rs.append(schemeId);
+		rs.append("$");
 		if (log_rounds < 10)
 			rs.append("0");
 		if (log_rounds > 30) {


### PR DESCRIPTION
From release notes:
Introduce a gensalt() method that takes the schema id as a parameter and replace
the method with the original signature to use a default of '2a'. This change should
preserve compatibility with other bcrypt libraries that are not yet updated to
handle the '2b' schema.
